### PR TITLE
Add offline fallback page for service worker

### DIFF
--- a/offline.html
+++ b/offline.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <title>オフライン</title>
+</head>
+<body>
+  <h1>オフラインです</h1>
+  <p>インターネット接続を確認してください。</p>
+</body>
+</html>

--- a/sw.js
+++ b/sw.js
@@ -5,7 +5,8 @@ const urlsToCache = [
   './logo.png',
   './pkg/rust_image.js',
   './pkg/rust_image_bg.wasm',
-  './alpine.js'
+  './alpine.js',
+  './offline.html'
 ];
 
 // インストール時のキャッシュ
@@ -63,7 +64,7 @@ self.addEventListener('fetch', event => {
           });
 
           return response;
-        });
+        }).catch(() => caches.match('./offline.html'));
       })
   );
-}); 
+});


### PR DESCRIPTION
## Summary
- cache new offline fallback page in service worker
- return offline page when network fetch fails

## Testing
- `cargo test`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c0d27ef0a083249c875f7f61684beb