### PR TITLE
Display history images as thumbnails

### DIFF
--- a/index.html
+++ b/index.html
@@ -217,6 +217,44 @@
             justify-content: center;
             gap: 0.5rem;
         }
+        .thumbnail-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(100px, 1fr));
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+        .thumbnail {
+            width: 100%;
+            height: auto;
+            cursor: pointer;
+            border-radius: 0.25rem;
+        }
+        .modal {
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            background: rgba(0, 0, 0, 0.5);
+            display: flex;
+            justify-content: center;
+            align-items: center;
+        }
+        .modal-content {
+            background: white;
+            padding: 1rem;
+            border-radius: 0.5rem;
+            max-width: 90%;
+            max-height: 90%;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+        }
+        .modal-content img {
+            max-width: 100%;
+            max-height: 80vh;
+            margin-bottom: 1rem;
+        }
         @media (min-width: 768px) {
             .container {
                 padding: 2rem;
@@ -345,15 +383,22 @@
             <div x-show="showHistory" x-cloak id="history-section">
                 <h2>履歴</h2>
                 <button class="btn" @click="clearHistory">履歴をクリア</button>
-                <template x-for="(item, index) in history" :key="index">
-                    <div class="image-container">
-                        <img :src="item.dataUrl" alt="History Image">
-                        <div class="actions">
-                            <button class="btn" @click="downloadHistoryImage(index)">ダウンロード</button>
-                            <button class="btn" @click="shareHistoryImage(index)">共有</button>
-                        </div>
+                <div class="thumbnail-grid">
+                    <template x-for="(item, index) in history" :key="index">
+                        <img class="thumbnail" :src="item.dataUrl" alt="History Image" @click="openHistoryImage(index)">
+                    </template>
+                </div>
+            </div>
+
+            <div x-show="selectedHistoryIndex !== null" x-cloak class="modal" @click.self="closeHistoryImage">
+                <div class="modal-content">
+                    <img :src="history[selectedHistoryIndex].dataUrl" alt="History Image">
+                    <div class="actions">
+                        <button class="btn" @click="downloadHistoryImage(selectedHistoryIndex)">ダウンロード</button>
+                        <button class="btn" @click="shareHistoryImage(selectedHistoryIndex)">共有</button>
+                        <button class="btn" @click="closeHistoryImage">閉じる</button>
                     </div>
-                </template>
+                </div>
             </div>
         </div>
     </div>
@@ -398,6 +443,7 @@
                 resizedBlob: null,
                 resize_image: null,
                 history: [],
+                selectedHistoryIndex: null,
 
                 async init() {
                     const wasm = await import('./pkg/rust_image.js');
@@ -588,6 +634,14 @@
                     reader.readAsDataURL(blob);
                 },
 
+                openHistoryImage(index) {
+                    this.selectedHistoryIndex = index;
+                },
+
+                closeHistoryImage() {
+                    this.selectedHistoryIndex = null;
+                },
+
                 downloadHistoryImage(index) {
                     const item = this.history[index];
                     const link = document.createElement('a');
@@ -622,6 +676,7 @@
                     this.history = [];
                     localStorage.removeItem('resizeHistory');
                     this.showHistory = false;
+                    this.selectedHistoryIndex = null;
                 }
             }))
         });


### PR DESCRIPTION
## Summary
- Show image history as grid of thumbnails
- Open clicked history image in modal with download/share options

## Testing
- `wasm-pack build --target web --no-opt`


------
https://chatgpt.com/codex/tasks/task_e_68c0f546f210832483a569d31b5e5d86